### PR TITLE
export theme

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,3 +13,4 @@ export { default as RadioWithLabel } from './components/RadioWithLabel';
 export { default as Spin } from './components/Spin';
 export { default as TextField } from './components/TextField';
 export { default as UnorderedList } from './components/UnorderedList';
+export { default as theme } from './components/theme';


### PR DESCRIPTION
Have perts-ui export a default theme so other apps can consume and possible extend it.

The near-term use for this is setting colors in reports.

## Testing

I installed perts-ui at this commit in package.json of the universal report app, then rendered components using the colors.

```
import { theme } from 'perts-ui';

const myDiv = styled.div`
  color: ${theme.colors.grayDark};
`;
```