### PR TITLE
Allow custom theme settings

### DIFF
--- a/lib/components/AAAExampleUsage/index.stories.js
+++ b/lib/components/AAAExampleUsage/index.stories.js
@@ -4,12 +4,41 @@ import { withA11y } from '@storybook/addon-a11y';
 // https://github.com/storybookjs/storybook/tree/master/addons/knobs
 import { withKnobs } from '@storybook/addon-knobs';
 
-import { Button, Card, CheckboxWithLabel, TextField } from '../..';
+import { theme, Button, Card, CheckboxWithLabel, TextField } from '../..';
 import { FaChevronCircleRight } from 'react-icons/fa';
+import { ThemeProvider } from 'styled-components';
 
 export default {
   title: 'Example Usage',
   decorators: [withKnobs, withA11y],
+};
+
+export const Themeable = () => {
+  // NOTE: You would probably not usually create a new theme within a component.
+  // This is happening here so that the custom theme code is highlighted in the
+  // Story tab of Storybook.
+  const customTheme = {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      primary: '#6f4a8e',
+    },
+  };
+
+  return (
+    <ThemeProvider theme={customTheme}>
+      <Card>
+        <Card.Title>Components are Themeable</Card.Title>
+        <Card.Content>
+          Using styled-component&rsquo;s{' '}
+          <a href="https://styled-components.com/docs/advanced#theming">
+            ThemeProvider
+          </a>{' '}
+          you can override the default theme settings in perts-ui if needed.
+        </Card.Content>
+      </Card>
+    </ThemeProvider>
+  );
 };
 
 export const LoginScreen = () => {

--- a/lib/components/Button/index.js
+++ b/lib/components/Button/index.js
@@ -58,8 +58,12 @@ Button.propTypes = {
 
 const ButtonText = styled.div`
   flex-grow: 1;
-  padding: ${theme.units.fieldPadding};
+  padding: ${(props) => props.theme.units.fieldPadding};
 `;
+
+ButtonText.defaultProps = {
+  theme,
+};
 
 const ButtonGutter = styled.div`
   flex-basis: 48px;
@@ -68,6 +72,10 @@ const ButtonGutter = styled.div`
   align-items: center;
   justify-content: center;
 `;
+
+ButtonGutter.defaultProps = {
+  theme,
+};
 
 const ButtonStyled = styled.button`
   display: flex;
@@ -81,30 +89,34 @@ const ButtonStyled = styled.button`
   font-size: 0.89rem;
   font-weight: bold;
 
-  color: ${theme.colors.white};
-  background-color: ${theme.colors.primary};
+  color: ${(props) => props.theme.colors.white};
+  background-color: ${(props) => props.theme.colors.primary};
 
   border: 0;
-  border-radius: ${theme.units.borderRadius};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   cursor: pointer;
 
   &:enabled:active {
-    background: ${theme.colors.primaryDark};
+    background: ${(props) => props.theme.colors.primaryDark};
   }
 
   ${(props) =>
     props.disabled &&
     css`
-      background-color: ${theme.colors.disabled};
+      background-color: ${props.theme.colors.disabled};
       cursor: not-allowed;
     `};
 
   &:focus {
     outline: 0;
-    box-shadow: 0 0 0 5px ${theme.colors.primaryLight};
+    box-shadow: 0 0 0 5px ${(props) => props.theme.colors.primaryLight};
   }
 `;
+
+ButtonStyled.defaultProps = {
+  theme,
+};
 
 ButtonText.displayName = 'ButtonText';
 ButtonGutter.displayName = 'ButtonGutter';

--- a/lib/components/Card/index.js
+++ b/lib/components/Card/index.js
@@ -7,32 +7,36 @@ import theme from '../theme';
 import CardTitleGraphic from './CardTitleGraphic.png';
 
 const CardStyled = styled.div`
-  margin-bottom: ${theme.units.fieldPadding};
+  margin-bottom: ${(props) => props.theme.units.fieldPadding};
 
-  background: ${theme.colors.white};
-  color: ${theme.colors.text};
+  background: ${(props) => props.theme.colors.white};
+  color: ${(props) => props.theme.colors.text};
 
-  border-radius: ${theme.units.borderRadius};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   /* So children don't flow outside border-radius. */
   overflow: hidden;
 
   /* So last child's bottom left/right borders don't get cut off. */
   > :last-child {
-    border-bottom-right-radius: ${theme.units.borderRadius};
-    border-bottom-left-radius: ${theme.units.borderRadius};
+    border-bottom-right-radius: ${(props) => props.theme.units.borderRadius};
+    border-bottom-left-radius: ${(props) => props.theme.units.borderRadius};
   }
 `;
 
+CardStyled.defaultProps = {
+  theme,
+};
+
 const CardTitleStyled = styled.div`
-  background: ${theme.colors.primary};
-  color: ${theme.colors.white};
+  background: ${(props) => props.theme.colors.primary};
+  color: ${(props) => props.theme.colors.white};
 
   font-weight: bold;
 
-  border: 1px solid ${theme.colors.primary};
+  border: 1px solid ${(props) => props.theme.colors.primary};
 
-  padding: ${theme.units.padding};
+  padding: ${(props) => props.theme.units.padding};
 
   background-image: url(${CardTitleGraphic});
   background-size: 167px 96px;
@@ -40,12 +44,16 @@ const CardTitleStyled = styled.div`
   background-position: top right -50px;
 `;
 
-const CardContentStyled = styled.div`
-  padding: ${theme.units.padding};
+CardTitleStyled.defaultProps = {
+  theme,
+};
 
-  border-bottom: 1px solid ${theme.colors.grayLight};
-  border-left: 1px solid ${theme.colors.grayLight};
-  border-right: 1px solid ${theme.colors.grayLight};
+const CardContentStyled = styled.div`
+  padding: ${(props) => props.theme.units.padding};
+
+  border-bottom: 1px solid ${(props) => props.theme.colors.grayLight};
+  border-left: 1px solid ${(props) => props.theme.colors.grayLight};
+  border-right: 1px solid ${(props) => props.theme.colors.grayLight};
 
   /*
     Setting margin-top and margin-bottom so that the spacing set by the above
@@ -59,6 +67,10 @@ const CardContentStyled = styled.div`
     margin-bottom: 0;
   }
 `;
+
+CardContentStyled.defaultProps = {
+  theme,
+};
 
 const Card = ({ children, className, title = false }) => {
   const cx = classNames(className);

--- a/lib/components/Checkbox/index.js
+++ b/lib/components/Checkbox/index.js
@@ -42,9 +42,13 @@ const CheckboxContainer = styled.div`
 
 const Icon = styled.svg`
   fill: none;
-  stroke: ${theme.colors.primary};
+  stroke: ${(props) => props.theme.colors.primary};
   stroke-width: 3px;
 `;
+
+Icon.defaultProps = {
+  theme,
+};
 
 const HiddenCheckbox = styled.input.attrs({ type: 'checkbox' })`
   /*
@@ -63,23 +67,28 @@ const HiddenCheckbox = styled.input.attrs({ type: 'checkbox' })`
 `;
 
 const StyledCheckbox = styled.div`
-  width: ${theme.units.checkboxSize};
-  height: ${theme.units.checkboxSize};
+  width: ${(props) => props.theme.units.checkboxSize};
+  height: ${(props) => props.theme.units.checkboxSize};
 
   background: ${(props) =>
-    props.checked ? theme.colors.white : 'transparent'};
+    props.checked ? props.theme.colors.white : 'transparent'};
 
   border: 2px solid
-    ${(props) => (props.checked ? theme.colors.white : theme.colors.grayDark)};
-  border-radius: ${theme.units.borderRadius};
+    ${(props) =>
+      props.checked ? props.theme.colors.white : props.theme.colors.grayDark};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   transition: all 150ms;
 
   ${HiddenCheckbox}:focus + & {
-    box-shadow: 0 0 0 5px ${theme.colors.primaryLight};
+    box-shadow: 0 0 0 5px ${(props) => props.theme.colors.primaryLight};
   }
 
   ${Icon} {
     visibility: ${(props) => (props.checked ? 'visible' : 'hidden')};
   }
 `;
+
+StyledCheckbox.defaultProps = {
+  theme,
+};

--- a/lib/components/CheckboxWithLabel/index.js
+++ b/lib/components/CheckboxWithLabel/index.js
@@ -64,32 +64,43 @@ const CheckboxLabel = styled.label`
   flex-direction: row;
   align-items: center;
 
-  margin-bottom: ${theme.units.fieldPadding};
-  padding: ${theme.units.fieldPadding};
+  margin-bottom: ${(props) => props.theme.units.fieldPadding};
+  padding: ${(props) => props.theme.units.fieldPadding};
 
   cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
 
   border: 1px solid
     ${(props) =>
-      props.checked ? theme.colors.primary : theme.colors.grayMedium};
-  border-radius: ${theme.units.borderRadius};
+      props.checked
+        ? props.theme.colors.primary
+        : props.theme.colors.grayMedium};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   ${(props) =>
     props.disabled &&
     css`
-      border: 1px dashed ${theme.colors.grayMedium};
+      border: 1px dashed ${props.theme.colors.grayMedium};
     `};
 
   background: ${(props) =>
-    props.checked ? theme.colors.primary : theme.colors.white};
+    props.checked ? props.theme.colors.primary : props.theme.colors.white};
 
-  color: ${(props) => (props.checked ? theme.colors.white : theme.colors.text)};
+  color: ${(props) =>
+    props.checked ? props.theme.colors.white : props.theme.colors.text};
 `;
+
+CheckboxLabel.defaultProps = {
+  theme,
+};
 
 const CheckboxLabelText = styled.div`
   margin-left: ${theme.units.fieldPadding};
   font-size: ${theme.units.fontSizeBase};
 `;
+
+CheckboxLabelText.defaultProps = {
+  theme,
+};
 
 CheckboxLabel.displayName = 'CheckboxLabel';
 CheckboxLabelText.displayName = 'CheckboxLabelText';

--- a/lib/components/FlexCol/index.js
+++ b/lib/components/FlexCol/index.js
@@ -23,7 +23,7 @@ const FlexCol = styled(Flex)`
     margin-top: ${(props) =>
       props.spacing !== undefined
         ? `${props.spacing}px`
-        : theme.units.fieldPadding};
+        : props.theme.units.fieldPadding};
   }
 
   ${FlexItem}:empty {
@@ -35,6 +35,10 @@ FlexCol.propTypes = {
   alignItems: PropTypes.string,
   justifyContent: PropTypes.string,
   spacing: PropTypes.number,
+};
+
+FlexCol.defaultProps = {
+  theme,
 };
 
 export default FlexCol;

--- a/lib/components/FlexRow/index.js
+++ b/lib/components/FlexRow/index.js
@@ -23,7 +23,7 @@ const FlexRow = styled(Flex)`
     margin-left: ${(props) =>
       props.spacing !== undefined
         ? `${props.spacing}px`
-        : theme.units.fieldPadding};
+        : props.theme.units.fieldPadding};
   }
 
   ${FlexItem}:empty {
@@ -35,6 +35,10 @@ FlexRow.propTypes = {
   alignItems: PropTypes.string,
   justifyContent: PropTypes.string,
   spacing: PropTypes.number,
+};
+
+FlexRow.defaultProps = {
+  theme,
 };
 
 export default FlexRow;

--- a/lib/components/InputField/index.js
+++ b/lib/components/InputField/index.js
@@ -6,8 +6,12 @@ import styled from 'styled-components';
 import theme from '../theme';
 
 const InputField = styled.div`
-  margin-bottom: ${theme.units.fieldPadding};
+  margin-bottom: ${(props) => props.theme.units.fieldPadding};
 `;
+
+InputField.defaultProps = {
+  theme,
+};
 
 InputField.displayName = 'InputField';
 

--- a/lib/components/InputFieldError/index.js
+++ b/lib/components/InputFieldError/index.js
@@ -6,16 +6,20 @@ import styled from 'styled-components';
 import theme from '../theme';
 
 const InputFieldError = styled.div`
-  margin-top: ${theme.units.fieldPaddingInternal};
-  padding: ${theme.units.fieldPadding};
+  margin-top: ${(props) => props.theme.units.fieldPaddingInternal};
+  padding: ${(props) => props.theme.units.fieldPadding};
 
-  border-radius: ${theme.units.borderRadius};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
-  background: ${theme.colors.warning};
-  color: ${theme.colors.white};
+  background: ${(props) => props.theme.colors.warning};
+  color: ${(props) => props.theme.colors.white};
 
   text-align: center;
 `;
+
+InputFieldError.defaultProps = {
+  theme,
+};
 
 InputFieldError.displayName = 'InputFieldError';
 

--- a/lib/components/InputFieldLabel/index.js
+++ b/lib/components/InputFieldLabel/index.js
@@ -8,7 +8,7 @@ import theme from '../theme';
 const InputFieldLabel = styled.label`
   display: inline-block;
 
-  margin-bottom: ${theme.units.fieldPaddingInternal};
+  margin-bottom: ${(props) => props.theme.units.fieldPaddingInternal};
 
   font-weight: 700;
   /*
@@ -21,6 +21,10 @@ const InputFieldLabel = styled.label`
   /* Set line height to elements font-size resuling height. */
   line-height: 1em;
 `;
+
+InputFieldLabel.defaultProps = {
+  theme,
+};
 
 InputFieldLabel.displayName = 'InputFieldLabel';
 

--- a/lib/components/Legend/index.js
+++ b/lib/components/Legend/index.js
@@ -22,19 +22,23 @@ const LegendStyled = styled.legend`
   width: 100%;
   font-weight: 700;
 
-  margin-bottom: ${theme.units.fieldPadding};
-  padding: ${theme.units.fieldPadding};
+  margin-bottom: ${(props) => props.theme.units.fieldPadding};
+  padding: ${(props) => props.theme.units.fieldPadding};
 
-  background: ${theme.colors.primaryLight};
+  background: ${(props) => props.theme.colors.primaryLight};
   background: linear-gradient(
     0deg,
-    ${theme.colors.white} 0%,
-    ${theme.colors.white} 45%,
-    ${theme.colors.primaryLight} 100%
+    ${(props) => props.theme.colors.white} 0%,
+    ${(props) => props.theme.colors.white} 45%,
+    ${(props) => props.theme.colors.primaryLight} 100%
   );
-  color: ${theme.colors.text};
+  color: ${(props) => props.theme.colors.text};
 
-  border-radius: ${theme.units.borderRadius};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 `;
+
+LegendStyled.defaultProps = {
+  theme,
+};
 
 export default Legend;

--- a/lib/components/ListItem/index.js
+++ b/lib/components/ListItem/index.js
@@ -66,7 +66,7 @@ const IconStyled = styled.span`
   top: 0.14em;
   text-align: center;
 
-  color: ${theme.colors.primary};
+  color: ${(props) => props.theme.colors.primary};
 
   ${(props) =>
     props.color &&
@@ -74,3 +74,7 @@ const IconStyled = styled.span`
       color: ${applyColor(props.color)};
     `};
 `;
+
+IconStyled.defaultProps = {
+  theme,
+};

--- a/lib/components/Loading/index.js
+++ b/lib/components/Loading/index.js
@@ -48,7 +48,7 @@ const LoadingStyles = styled.div`
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: ${theme.colors.grayMedium};
+    background-color: ${(props) => props.theme.colors.grayMedium};
     animation: ${folding} 2.4s infinite linear both;
     transform-origin: 100% 100%;
   }
@@ -77,6 +77,10 @@ const LoadingStyles = styled.div`
     animation-delay: 0.9s;
   }
 `;
+
+LoadingStyles.defaultProps = {
+  theme,
+};
 
 const Loading = () => (
   <LoadingPadding>

--- a/lib/components/Radio/index.js
+++ b/lib/components/Radio/index.js
@@ -42,9 +42,13 @@ const RadioContainer = styled.div`
 
 const Icon = styled.svg`
   fill: none;
-  stroke: ${theme.colors.primary};
+  stroke: ${(props) => props.theme.colors.primary};
   stroke-width: 3px;
 `;
+
+Icon.defaultProps = {
+  theme,
+};
 
 const HiddenRadio = styled.input.attrs({ type: 'radio' })`
   /*
@@ -63,23 +67,28 @@ const HiddenRadio = styled.input.attrs({ type: 'radio' })`
 `;
 
 const StyledRadio = styled.div`
-  width: ${theme.units.checkboxSize};
-  height: ${theme.units.checkboxSize};
+  width: ${(props) => props.theme.units.checkboxSize};
+  height: ${(props) => props.theme.units.checkboxSize};
 
   background: ${(props) =>
-    props.checked ? theme.colors.white : 'transparent'};
+    props.checked ? props.theme.colors.white : 'transparent'};
 
   border: 2px solid
-    ${(props) => (props.checked ? theme.colors.white : theme.colors.grayDark)};
+    ${(props) =>
+      props.checked ? props.theme.colors.white : props.theme.colors.grayDark};
   border-radius: 50%;
 
   transition: all 150ms;
 
   ${HiddenRadio}:focus + & {
-    box-shadow: 0 0 0 5px ${theme.colors.primaryLight};
+    box-shadow: 0 0 0 5px ${(props) => props.theme.colors.primaryLight};
   }
 
   ${Icon} {
     visibility: ${(props) => (props.checked ? 'visible' : 'hidden')};
   }
 `;
+
+StyledRadio.defaultProps = {
+  theme,
+};

--- a/lib/components/RadioWithLabel/index.js
+++ b/lib/components/RadioWithLabel/index.js
@@ -64,32 +64,43 @@ const RadioLabel = styled.label`
   flex-direction: row;
   align-items: center;
 
-  margin-bottom: ${theme.units.fieldPadding};
-  padding: ${theme.units.fieldPadding};
+  margin-bottom: ${(props) => props.theme.units.fieldPadding};
+  padding: ${(props) => props.theme.units.fieldPadding};
 
   cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
 
   border: 1px solid
     ${(props) =>
-      props.checked ? theme.colors.primary : theme.colors.grayMedium};
-  border-radius: ${theme.units.borderRadius};
+      props.checked
+        ? props.theme.colors.primary
+        : props.theme.colors.grayMedium};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   ${(props) =>
     props.disabled &&
     css`
-      border: 1px dashed ${theme.colors.grayMedium};
+      border: 1px dashed ${props.theme.colors.grayMedium};
     `};
 
   background: ${(props) =>
-    props.checked ? theme.colors.primary : theme.colors.white};
+    props.checked ? props.theme.colors.primary : props.theme.colors.white};
 
-  color: ${(props) => (props.checked ? theme.colors.white : theme.colors.text)};
+  color: ${(props) =>
+    props.checked ? props.theme.colors.white : props.theme.colors.text};
 `;
+
+RadioLabel.defaultProps = {
+  theme,
+};
 
 const RadioLabelText = styled.div`
-  margin-left: ${theme.units.fieldPadding};
-  font-size: ${theme.units.fontSizeBase};
+  margin-left: ${(props) => props.theme.units.fieldPadding};
+  font-size: ${(props) => props.theme.units.fontSizeBase};
 `;
+
+RadioLabelText.defaultProps = {
+  theme,
+};
 
 RadioLabel.displayName = 'RadioLabel';
 RadioLabelText.displayName = 'RadioLabelText';

--- a/lib/components/TextField/index.js
+++ b/lib/components/TextField/index.js
@@ -81,18 +81,18 @@ const TextFieldStyled = styled.input`
   flex-direction: row;
 
   width: 100%;
-  padding: ${theme.units.fieldPadding};
+  padding: ${(props) => props.theme.units.fieldPadding};
 
-  border: 1px solid ${theme.colors.grayMedium};
-  border-radius: ${theme.units.borderRadius};
+  border: 1px solid ${(props) => props.theme.colors.grayMedium};
+  border-radius: ${(props) => props.theme.units.borderRadius};
 
   ${(props) =>
     props.disabled &&
     css`
-      background: ${theme.colors.fieldBackgroundDisabled};
-      color: ${theme.colors.text};
+      background: ${props.theme.colors.fieldBackgroundDisabled};
+      color: ${props.theme.colors.text};
 
-      border: 1px dashed ${theme.colors.grayMedium};
+      border: 1px dashed ${props.theme.colors.grayMedium};
 
       cursor: not-allowed;
     `};
@@ -100,20 +100,24 @@ const TextFieldStyled = styled.input`
   ${(props) =>
     props.readOnly &&
     css`
-      color: ${theme.colors.textDisabled};
+      color: ${props.theme.colors.textDisabled};
     `};
 
   ${(props) =>
     props.error &&
     css`
-      border-color: ${theme.colors.warning};
+      border-color: ${props.theme.colors.warning};
     `};
 
   &:focus {
     outline: 0;
-    box-shadow: 0 0 0 5px ${theme.colors.primaryLight};
+    box-shadow: 0 0 0 5px ${(props) => props.theme.colors.primaryLight};
   }
 `;
+
+TextFieldStyled.defaultProps = {
+  theme,
+};
 
 const TextFieldContainer = styled.div`
   position: relative;
@@ -126,6 +130,10 @@ const TextFieldRequired = styled.span`
   height: 8px;
   width: 8px;
   border-radius: 50%;
-  background: ${theme.colors.warning};
+  background: ${(props) => props.theme.colors.warning};
   content: '';
 `;
+
+TextFieldRequired.defaultProps = {
+  theme,
+};

--- a/lib/components/Toggle/ToggleStyled.js
+++ b/lib/components/Toggle/ToggleStyled.js
@@ -29,7 +29,7 @@ const ToggleStyled = styled(InputField)`
     &:checked ~ .control {
       &:after {
         left: 22px;
-        background-color: ${theme.colors.primary};
+        background-color: ${(props) => props.theme.colors.primary};
       }
     }
   }
@@ -39,8 +39,8 @@ const ToggleStyled = styled(InputField)`
     height: 38px;
     width: 60px;
 
-    background: ${theme.colors.grayLight};
-    border: 1px solid ${theme.colors.grayMedium};
+    background: ${(props) => props.theme.colors.grayLight};
+    border: 1px solid ${(props) => props.theme.colors.grayMedium};
     border-radius: 20px;
 
     &:after {
@@ -50,10 +50,10 @@ const ToggleStyled = styled(InputField)`
       left: 0;
       height: 36px;
       width: 36px;
-      border: 1px solid ${theme.colors.white};
+      border: 1px solid ${(props) => props.theme.colors.white};
       border-radius: 50%;
 
-      background-color: ${theme.colors.grayDark};
+      background-color: ${(props) => props.theme.colors.grayDark};
       background-image: url(${iconToggle});
       background-repeat: no-repeat;
       background-size: contain, cover;
@@ -64,5 +64,9 @@ const ToggleStyled = styled(InputField)`
     }
   }
 `;
+
+ToggleStyled.defaultProps = {
+  theme,
+};
 
 export default ToggleStyled;

--- a/lib/components/UnorderedList/index.js
+++ b/lib/components/UnorderedList/index.js
@@ -22,5 +22,9 @@ const ULStyled = styled.ul`
   padding-left: 0;
   margin-left: 2.1em;
   list-style-type: none;
-  line-height: ${theme.units.lineHeight};
+  line-height: ${(props) => props.theme.units.lineHeight};
 `;
+
+ULStyled.defaultProps = {
+  theme,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,3 +18,4 @@ export { default as Spin } from './components/Spin';
 export { default as TextField } from './components/TextField';
 export { default as Toggle } from './components/Toggle';
 export { default as UnorderedList } from './components/UnorderedList';
+export { default as theme } from './components/theme';


### PR DESCRIPTION
In support of work for the Figure fix in triton, I'm creating some components in perts-ui. Those are relying a breakpoints for media queries. Our different apps have different breakpoints. So need a way to specify those with our perts-ui use. This allows that. Added a storybook story to provide an example of how it works.

There's more work incoming. But I wanted to separate this out into a smaller pr since it touches a lot of files.