### PR TITLE
Add Image component

### DIFF
--- a/lib/components/Image/index.js
+++ b/lib/components/Image/index.js
@@ -1,0 +1,36 @@
+import styled, { css } from 'styled-components';
+
+const Image = styled.img`
+  /*
+    Avoid the extra space that occurs when an image is displayed inline.
+    https://stackoverflow.com/questions/5804256/image-inside-div-has-extra-space-below-the-image
+  */
+  display: ${(props) => (props.display ? props.display : 'block')};
+
+  /*
+    By default, the image height will adjust. This is recommended for most cases
+    since you're probably using this for dynamic widths. But you can override
+    this if you need to.
+  */
+  height: ${(props) => (props.height ? props.height : 'auto')};
+
+  /*
+    Reduce the width of the image to fit parent element.
+  */
+  ${(props) =>
+    props.sizeDown &&
+    css`
+      max-width: 100%;
+    `};
+
+  /*
+    Increase the width of the image to expand to parent element.
+  */
+  ${(props) =>
+    props.sizeUp &&
+    css`
+      width: 100%;
+    `};
+`;
+
+export default Image;

--- a/lib/components/Image/index.js
+++ b/lib/components/Image/index.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
 
 const Image = styled.img`
   /*
@@ -32,5 +33,12 @@ const Image = styled.img`
       width: 100%;
     `};
 `;
+
+Image.propTypes = {
+  display: PropTypes.string,
+  height: PropTypes.string,
+  sizeDown: PropTypes.bool,
+  sizeUp: PropTypes.bool,
+};
 
 export default Image;

--- a/lib/components/Image/index.stories.js
+++ b/lib/components/Image/index.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+// https://github.com/storybookjs/storybook/tree/master/addons/a11y
+import { withA11y } from '@storybook/addon-a11y';
+// https://github.com/storybookjs/storybook/tree/master/addons/knobs
+import { withKnobs } from '@storybook/addon-knobs';
+
+import Image from './';
+import Row from '../Row';
+import Col from '../Col';
+import LoremText from '../LoremText';
+
+export default {
+  title: 'Image',
+  component: Image,
+  decorators: [withKnobs, withA11y],
+};
+
+export const Default = () => (
+  <div style={{ width: '300px', border: '1px solid purple' }}>
+    <Image src="http://placekitten.com/1000/600" alt="" />
+  </div>
+);
+
+export const SizeDown = () => (
+  <div style={{ maxWidth: '300px', border: '1px solid purple' }}>
+    <Image src="http://placekitten.com/1000/600" sizeDown alt="" />
+  </div>
+);
+
+export const SizeUp = () => (
+  <Image src="http://placekitten.com/500/300" sizeUp alt="" />
+);
+
+export const FullyResponsive = () => (
+  <Row>
+    <Col colsMd={9} colsSm={12}>
+      <LoremText />
+    </Col>
+    <Col colsMd={3} colsSm={12}>
+      <Image src="http://placekitten.com/500/300" sizeDown sizeUp alt="" />
+    </Col>
+  </Row>
+);

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ export { default as FlexCol } from './components/FlexCol';
 export { default as FlexItem } from './components/FlexItem';
 export { default as FlexRow } from './components/FlexRow';
 export { default as HelloWorld } from './components/HelloWorld';
+export { default as Image } from './components/Image';
 export { default as Legend } from './components/Legend';
 export { default as ListItem } from './components/ListItem';
 export { default as Loading } from './components/Loading';


### PR DESCRIPTION
## Background

Closes #21. Create an Image component that allows for dynamic/responsive resizing.

## Implementation

Keeping it simple. `sizeDown` will cause the image to reduce in size to remain within the bounds of the parent. `sizeUp` will cause the image to expand in size to the parent. You can use both at the same time.

This component doesn't provide for alternate images based on media queries, it's just resizing the `src` image.

## Testing

Added Storybook stories.