### PR TITLE
feat: add focus outline to Toggle

### DIFF
--- a/lib/components/Toggle/ToggleStyled.js
+++ b/lib/components/Toggle/ToggleStyled.js
@@ -32,6 +32,10 @@ const ToggleStyled = styled(InputField)`
         background-color: ${(props) => props.theme.colors.primary};
       }
     }
+
+    &:focus ~ .control {
+      outline: 3px solid ${(props) => props.theme.colors.primary};
+    }
   }
 
   .control {


### PR DESCRIPTION
## Background

Re: https://github.com/perts/saturn/issues/398

## Implementation

Added an outline when the input is focused.

## Screenshots

### Storybook

<img width="234" alt="Screen Shot 2023-01-19 at 10 04 43 AM" src="https://user-images.githubusercontent.com/276924/213492534-6d7c8fe5-cf49-4f41-93f9-5325c5655a7a.png">

<img width="229" alt="Screen Shot 2023-01-19 at 10 04 49 AM" src="https://user-images.githubusercontent.com/276924/213492551-76c9c103-a5be-436b-aa47-250d37353f94.png">

### In Saturn

<img width="856" alt="Screen Shot 2023-01-19 at 10 03 37 AM" src="https://user-images.githubusercontent.com/276924/213492715-422dc9d0-5e79-44a9-8053-c518ec47c165.png">


## Testing

- `npm run storybook` to view the focus state.
- Also updated `perts/saturn` to use the new commit hash `1c6fd29` to view it in app.